### PR TITLE
Added xd-storage-helper to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ## Awesome Plugins
 
 ## Utility Libraries
+- [**Storage helper (xd-storage-helper)**][4] – A little helper library making key-value-based permanent storage for plugins easy
 
 ## Developer Tools
 - [**Typescript definitions**][1] – Adding autocompletion and type definitions
@@ -37,3 +38,4 @@ To contribute, please follow these steps:
 [1]:	https://github.com/AdobeXD/typings
 [2]:	https://github.com/takidelfin/xd-awesome-logo/
 [3]:  https://github.com/AdobeXD/xdpm
+[4]:  https://github.com/pklaschka/xd-storage-helper

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Awesome Plugins
 
 ## Utility Libraries
-- [**Storage helper (xd-storage-helper)**][4] – A little helper library making key-value-based permanent storage for plugins easy
+- [**Storage helper (xd-storage-helper)**][4] – A small helper library making key-value-based permanent storage for plugins easy
 
 ## Developer Tools
 - [**Typescript definitions**][1] – Adding autocompletion and type definitions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the xd-storage-helper mini-library to the list (see #7 for details)

## Related Issue

closes #7 

## Motivation and Context

It's a little helper for key-value-pair permanent storage I used in my own plugins (available open-source under the MIT license)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] I have read the **CONTRIBUTING** document.
