### PR TITLE
Adds xd-plugin-helper to utility libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-<p align="center"> 
+<p align="center">
   <img src="xdawesome.svg" width="500">
   <br />
-  Awesome XD Plugins, Templates, Samples, and more. 
+  Awesome XD Plugins, Templates, Samples, and more.
   <br /> <br />
 </p>
 
 ## Awesome Plugins
 
 ## Utility Libraries
+- [**xd-plugin-helper**][4] - Collection of helpers for development
 
 ## Developer Tools
 - [**Typescript definitions**][1] – Adding autocompletion and type definitions
@@ -37,3 +38,4 @@ To contribute, please follow these steps:
 [1]:	https://github.com/AdobeXD/typings
 [2]:	https://github.com/takidelfin/xd-awesome-logo/
 [3]:  https://github.com/AdobeXD/xdpm
+[4]:  https://github.com/svschannak/xd-plugin-helper


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changes the list of utility libraries to add a link to xd-plugin-heler

## Related Issue

#11

## Motivation and Context

I would like to add my small helper library, that i will extend in the next weeks and where I love to integrate helpers from other devs too. For now it has a helper to add error hints to nodes on an artboard.

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] I have read the **CONTRIBUTING** document.
