### PR TITLE
Adds resource for xd-json-wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 ## Utility Libraries
 - [**Storage helper (xd-storage-helper)**][4] – A small helper library making key-value-based permanent storage for plugins easy
 - [**xd-plugin-helper**][5] - Collection of helpers for development
+- [**xd-json-wrapper**][6] - Wrapper for XD Nodes, Artboards and document to convert to json
 
 ## Developer Tools
 - [**Typescript definitions**][1] – Adding autocompletion and type definitions
@@ -43,3 +44,4 @@ To contribute, please follow these steps:
 [3]:  https://github.com/AdobeXD/xdpm
 [4]:  https://github.com/pklaschka/xd-storage-helper
 [5]:  https://github.com/svschannak/xd-plugin-helper
+[6]:  https://github.com/svschannak/xd-json-wrapper


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds the npm package xd-json-wrapper at utility libraries

## Related Issue

#14 

## Motivation and Context

Until now there is no easy way to use JSON.stringify()on nodes, artboards or the rootDocument. This library will change this behaviour with its wrapper classes.

## Checklist:

- [X ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ X] I have read the **CONTRIBUTING** document.
