### PR TITLE
generator-xd-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - [**xdpm**][3] - XD plugin manager CLI (useful for watching folders and creating plugin packages)
 
 ## Templates
+- [**generator-xd-plugin**](https://github.com/AdobeXD/generator-xd-plugin) – Yeoman generator for creating Adobe XD Plugin projects
 - [**pklaschka xd-plugin-boilerplate**](https://github.com/pklaschka/xd-plugin-boilerplate) – A template including bundling via Webpack, linting with ESLint as well as the typescript definitions preconfigured for JavaScript autocompletion
 
 ## Samples


### PR DESCRIPTION
# Submit your project for inclusion in XD-Awesome

## **generator-xd-plugin**

**Description of your project:** Yeoman generator for creating Adobe XD Plugin projects. 

**Link to your project:** https://github.com/AdobeXD/generator-xd-plugin

**License:** Apache 2.0

**Category:** Templates

## Why is it awesome?

This generator simply creates the scaffolding of files for XD Plugin using [webpack](https://webpack.github.io/) and [xdpm (Adobe XD Plugin Manager Command Line Tool)](https://github.com/AdobeXD/xdpm).

Also, this project  provides live-reloading of plugins. So that developers do not have to copy their plugin project files into develop folder. Developers may start coding almost as same style as webpack-dev-server.



## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html). (I'm an employee of Adobe)
- [x] I have read the **CONTRIBUTING** document.

