### PR TITLE
Add uiLogos plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - **[Copy SVG Code](https://github.com/stursby/xd-copy-svg-code-plugin)** by [Charlie Hield](https://github.com/stursby) - Plugin to generate SVG code from selection.
 - **[Artboard Plus](https://github.com/rodi01/Artboard-Plus-XD)** by [Rodrigo Soares](https://github.com/rodi01) - Artboard tools to speed up your Adobe XD workflow.
 - **[Inker8](https://github.com/inker8/xd-plugin)** by [Zack Young](https://github.com/zaaack) - Export artboards to a spec file for developers to measure design, copy css/text and export icons.
+- **[uiLogos](https://github.com/realvjy/uilogos-XD)** by [vijay verma](https://github.com/realvjy) - Insert professionally designed dummy logos of companies and 190+ country flags.
 
 ## Utility Libraries
 - [**xd-storage-helper**][4] – A small helper library making key-value-based permanent storage for plugins easy


### PR DESCRIPTION
Hello guys!

Sometimes we all need a professional logo as a placeholder and don't have time to create some dummy logos. Now you can quickly place dummy logos into Adobe XD.

- You can insert **25+ company logos** 
- v0.3.0 Also extended for **190+ country flags**.

More details here https://github.com/realvjy/uilogos-XD

thanks
vijay.