### PR TITLE
Add maps generator plugin to the plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 - **[Tunda Image](https://github.com/satriaajiputra/tunda-image)** by [Satria Aji Putra](https://github.com/satriaajiputra) - Quick fill image to a shape from direct image url
 - **[Export only one size](https://github.com/nikoladev/xd-export)** by [Nikola Pilipović](https://github.com/nikoladev) - Export at the scale you need and ONLY at the scale you need.
 - **[Mask Fit](https://github.com/paolobiagini/xd-mask-fit)** by [Paolo Biagini](https://github.com/paolobiagini) - A command-like plugin that allows fitting images to their mask.
+- **[Maps generator](https://github.com/boopeshmahendran/AdobeXD-maps)** by [Boopesh Mahendran](https://github.com/boopeshmahendran) - A map generator plugin for Adobe XD using google maps API.
 
 ## Utility Libraries
 - [**xd-storage-helper**][4] – A small helper library making key-value-based permanent storage for plugins easy


### PR DESCRIPTION
## **Maps generator**

**Description of your project:** A map generator plugin using Google Maps API
**Link to your project:** https://github.com/boopeshmahendran/AdobeXD-maps
**License:** MIT
**Category:** plugin

## Why is it awesome?

This plugin can **generate maps for any place in the world** and fill it inside Rectangles, ellipses and paths in XD. This plugin also provides options for changing the zoom level and the map type.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] I have read the **CONTRIBUTING** document.
