### PR TITLE
Added `xd-manifest-schema` – a JSON schema for the `manifest.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 ## Developer Tools
 - [**Typescript definitions**][1] – Adding autocompletion and type definitions
 - [**xdpm**][3] - XD plugin manager CLI (useful for watching folders and creating plugin packages)
+- [**xd-manifest-schema**][8] – A JSON schema to make editing and validating a plugin's `manifest.json` (adding capabilities for autocompletion, linting etc. in editors and IDEs)
 
 ## Templates
 - [**xd-plugin-boilerplate**](https://github.com/pklaschka/xd-plugin-boilerplate) – A template including bundling via Webpack, linting with ESLint as well as the typescript definitions preconfigured for JavaScript autocompletion
@@ -64,3 +65,4 @@
 [5]:  https://github.com/svschannak/xd-plugin-helper
 [6]:  https://github.com/svschannak/xd-json-wrapper
 [7]:  https://github.com/pklaschka/xd-localization-helper
+[8]:  https://github.com/pklaschka/xd-manifest-schema


### PR DESCRIPTION
# Submit your project for inclusion in XD-Awesome

Hey! We're happy you want to submit your project to XD-Awesome. Please create a pull request and ensure that you fill out the following template:

## **Name of your project or content**

**Description of your project:** JSON schema for the plugin `manifest.json`

**Link to your project:** https://github.com/pklaschka/xd-manifest-schema

**License:** MIT

**Category:** Developer tools

## Why is it awesome?

For the same reason the typings are: The schema adds autocompletion and linting capabilities to the `manifest.json` file for plugins, meaning developers don't need to memorize everything about the manifest.json specifications anymore...

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] I have read the **CONTRIBUTING** document.
