### PR TITLE
Add react-xd to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@
 ## Tutorials
 
 ## Framework Support
+- [**react-xd**](https://github.com/macintoshhelper/react-xd) - Render React components to Adobe XD. Build design systems and libraries from your code. This bundles your React app or UI library into a plugin with [xdpm](3).
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 ## Tutorials
 
 ## Framework Support
-- [**react-xd**](https://github.com/macintoshhelper/react-xd) - Render React components to Adobe XD. Build design systems and libraries from your code. This bundles your React app or UI library into a plugin with [xdpm](3).
+- [**react-xd**](https://github.com/macintoshhelper/react-xd) - Render React components to Adobe XD. Build design systems and libraries from your code. This bundles your React app or UI library into a plugin with [xdpm][3].
 
 ## Events
 


### PR DESCRIPTION
# Submit your project for inclusion in XD-Awesome

Hey! We're happy you want to submit your project to XD-Awesome. Please create a pull request and ensure that you fill out the following template:

## **react-xd**

**Description of your project:** Render React components to Adobe XD. Build design systems and libraries from your code.

**Link to your project:** https://github.com/macintoshhelper/react-xd

**License:** MIT license

**Category:** `Framework Support` (or would `Developer Tools` be better, or a new `Custom Renderers` section?)

## Why is it awesome?

This project lets you render your React app or components to Adobe XD. This can be used for React cross-platform UI libraries and for creating design systems. It is based off some of the primitives of the React Native API, so instead of replicating `react-dom`, it can provide a true mapping of a React UI library to an Adobe XD design, maintaining pixel perfection.

If a developer uses a system like `react-primitives` or `react-native-web`, they can maintain mappings to share their UI code with their web/native app and Adobe XD designs.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] I have read the **CONTRIBUTING** document.
